### PR TITLE
Fixes to compile with clang.

### DIFF
--- a/integers/intgauss.hpp
+++ b/integers/intgauss.hpp
@@ -47,7 +47,7 @@ static	GaussInt<GID>  itopower	   (int exp);
 		bool		   operator == (const GaussInt<GID>& target) const;
 		bool		   operator != (const GaussInt<GID>& target) const;
 	std::string print_me() const {
-		std::string ret = gi.r + std::string(gi.i>=0?" +":" ") + gi.i + "*i";
+		std::string ret = r + std::string(i>=0?" +":" ") + i + "*i";
 		return ret;
 	}
 	friend std::istream& operator >> (std::istream& is, GaussInt<GID>& gi) {

--- a/integers/private_data.hpp
+++ b/integers/private_data.hpp
@@ -71,7 +71,7 @@ public:
 		if (is.gcount() != buffer_size) {
 			YSVB_CHECK_1(is.gcount(), <, buffer_size, "Would not make any sense to be greater.")
 			for (
-				buffer[i = is.gcount()] = holder = (i?buffer[i-1]:tpd.get_lb()), i++;
+				i = is.gcount(), buffer[i] = holder = (i?buffer[i-1]:tpd.get_lb()), i++;
 				i < buffer_size;
 				i++
 			) {


### PR DESCRIPTION
1. `print_me` member function in `intgauss.hpp`
I don't know how it compiled with gcc since `gi` is a member function of the class. It makes no sense to access `gi.r` or `gi.i`.

2. `private_data.hpp`
You're setting and accessing the value of `i` in the same instruction. This an undefined behavior when compiled with clang, and it was causing segfault when trying to encrypt a file.